### PR TITLE
Fix setMeeting

### DIFF
--- a/src/main/java/seedu/address/model/meeting/NoConflictMeetingList.java
+++ b/src/main/java/seedu/address/model/meeting/NoConflictMeetingList.java
@@ -63,7 +63,8 @@ public class NoConflictMeetingList implements Iterable<Meeting> {
             throw new MeetingNotFoundException();
         }
 
-        if (contains(editedMeeting)) {
+        if (contains(editedMeeting) && !target.willConflict(editedMeeting)) {
+            // Any timing conflicts with the original timing is okay
             throw new ConflictingMeetingException();
         }
 


### PR DESCRIPTION
The original setMeeting will have prevented any existing meetings from being edited if they have the same time and date.

By checking if the editedMeeting DOES conflict with the originalMeeting (and only with the originalMeeting since NoConflictMeetingList enforces zero conflicts), we can tell if the editedMeeting is the same as the originalMeeting only with non timing changes (e.g., description changes).

Let's add a condition to check for conflicts with the original timing. If the contains evaluates to true, and the conflict is actually with the originalMeeting's timing, then there is no conflicts as it is just a simple update to the same exact meeting.