### PR TITLE
Make viewClient use new CommandResult constructor

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ViewClientCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewClientCommand.java
@@ -43,7 +43,7 @@ public class ViewClientCommand extends Command {
 
         Client clientToView = lastShownList.get(targetIndex.getZeroBased());
 
-        return new CommandResult(String.format(MESSAGE_SUCCESS, clientToView), false, false, true, false);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, clientToView), CommandSpecific.DETAILED_CLIENT);
     }
 
     @Override


### PR DESCRIPTION
Update viewClient to use new CommandResult constructor using enums instead. 