### PR TITLE
Fix invocation error when viewClient without args

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ViewClientCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ViewClientCommandParser.java
@@ -4,6 +4,8 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_INDEX;
 
+import java.util.stream.Stream;
+
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.ViewClientCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -21,6 +23,11 @@ public class ViewClientCommandParser implements Parser<ViewClientCommand> {
         requireNonNull(args);
         ArgumentMultimap argumentMultimap = ArgumentTokenizer.tokenize(args, PREFIX_INDEX);
 
+        if (!arePrefixesPresent(argumentMultimap, PREFIX_INDEX)
+                || !argumentMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewClientCommand.MESSAGE_USAGE));
+        }
+
         Index index;
         try {
             index = ParserUtil.parseIndex(argumentMultimap.getValue(PREFIX_INDEX).get());
@@ -29,5 +36,9 @@ public class ViewClientCommandParser implements Parser<ViewClientCommand> {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewClientCommand.MESSAGE_USAGE), pe);
         }
+    }
+
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 }

--- a/src/test/java/seedu/address/logic/parser/ViewClientCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ViewClientCommandParserTest.java
@@ -19,7 +19,16 @@ public class ViewClientCommandParserTest {
 
     @Test
     public void parse_invalidArgs_throwsParseException() {
+        // Invalid value after prefix
         assertParseFailure(parser, " i/a",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewClientCommand.MESSAGE_USAGE));
+
+        // No prefix
+        assertParseFailure(parser, "12",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewClientCommand.MESSAGE_USAGE));
+
+        // Empty string
+        assertParseFailure(parser, "",
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewClientCommand.MESSAGE_USAGE));
     }
 }


### PR DESCRIPTION
Add checks in the Parser to avoid invocation error.