### PR TITLE
Fix exit command causing NullPointerException

### DIFF
--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -35,7 +35,7 @@ public class CommandResult {
      * {@code specific} is set to their default value.
      */
     public CommandResult(String feedbackToUser, boolean showHelp, boolean exit) {
-        this(feedbackToUser, showHelp, exit, null);
+        this(feedbackToUser, showHelp, exit, CommandSpecific.NONSPECIFIC);
     }
 
     /**

--- a/src/main/java/seedu/address/logic/commands/CommandSpecific.java
+++ b/src/main/java/seedu/address/logic/commands/CommandSpecific.java
@@ -4,5 +4,5 @@ package seedu.address.logic.commands;
  * Represents what the command's execution is specific to, i.e., an AddMeetingCommand should be specific to MEETING.
  */
 public enum CommandSpecific {
-    CLIENT, MEETING, DETAILED_CLIENT, DETAILED_MEETING
+    CLIENT, MEETING, DETAILED_CLIENT, DETAILED_MEETING, NONSPECIFIC
 }

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -240,14 +240,6 @@ public class MainWindow extends UiPart<Stage> {
             logger.info("Result: " + commandResult.getFeedbackToUser());
             resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());
 
-            if (commandResult.isShowHelp()) {
-                handleHelp();
-            }
-
-            if (commandResult.isExit()) {
-                handleExit();
-            }
-
             switch (commandResult.getCommandSpecific()) {
             case CLIENT:
                 setListPanelToClient();
@@ -262,6 +254,14 @@ public class MainWindow extends UiPart<Stage> {
                 setListPanelToClientDetailed();
                 break;
             default:
+            }
+
+            if (commandResult.isShowHelp()) {
+                handleHelp();
+            }
+
+            if (commandResult.isExit()) {
+                handleExit();
             }
 
             return commandResult;


### PR DESCRIPTION
This bug is relatively insignficant in affecting the program's usability.

Due to a previous change in CommandSpecific (that removed a null check), HelpCommand and ExitCommand were both afflicted with this issue.

Hence, a new enum for CommandSpecific was added. This is to specify for commands that don't have any specificity in which window to show (Exit and Help currently). The overloaded constructor is also changed to default to this value.

The switch case in MainWindow is also shifted up. This is not a very important change as it is unlikely to happen again, but this is to hopefully prevent a similar issue in the future as we will be able to notice any exceptions caused by the switch block.