### PR TITLE
Fix stuck meeting not removing

### DIFF
--- a/src/main/java/seedu/address/model/MyInsuRec.java
+++ b/src/main/java/seedu/address/model/MyInsuRec.java
@@ -123,7 +123,7 @@ public class MyInsuRec implements ReadOnlyMyInsuRec {
     public void removeClient(Client client) {
         clients.remove(client);
         client.getMeetings().forEach(meetingToRemove -> {
-            if (meetings.contains(meetingToRemove)) {
+            if (meetings.containsSpecific(meetingToRemove)) {
                 meetings.remove(meetingToRemove);
             }
         });


### PR DESCRIPTION
Closes #266. 

This issue arises when meetings of the same start time and end time is added.

The current removeClient only removes those meetings which are in NCML, except the fact that whether it is contained in NCML is checked by willConflicts, which is problematic and not ideal, especially with the fact that meetings with the same time and end time can be added.

This solution involves a stricter check if the meetings in NCML is equal to the meeting being removed rather than if the meetings will conflict.