### PR TITLE
Fix invalid dates such as leap year

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.parser;
 
+import static java.time.format.ResolverStyle.STRICT;
 import static java.util.Objects.requireNonNull;
 
 import java.time.LocalDate;
@@ -110,7 +111,7 @@ public class ParserUtil {
     public static LocalDate parseDate(String date, String type) throws ParseException {
         requireNonNull(date);
         try {
-            return LocalDate.parse(date, DateTimeFormatter.ofPattern("ddMMyyyy"));
+            return LocalDate.parse(date, DateTimeFormatter.ofPattern("ddMMuuuu").withResolverStyle(STRICT));
         } catch (DateTimeParseException e) {
             if (type.equals("meeting")) {
                 throw new ParseException(MeetingDate.MESSAGE_CONSTRAINTS);

--- a/src/main/java/seedu/address/model/client/Birthday.java
+++ b/src/main/java/seedu/address/model/client/Birthday.java
@@ -15,7 +15,7 @@ public class Birthday {
 
     public static final String VALIDATION_REGEX = "^([0-2][0-9]||3[0-1])(0[0-9]||1[0-2])([0-9][0-9])?[0-9][0-9]$";
     public static final String MESSAGE_CONSTRAINTS =
-            "Birthday should be in the format DDMMYYYY";
+            "Birthday should be in the format DDMMYYYY and should be a valid day of the year";
     private final LocalDate birthday;
 
     /**

--- a/src/main/java/seedu/address/model/meeting/MeetingDate.java
+++ b/src/main/java/seedu/address/model/meeting/MeetingDate.java
@@ -11,7 +11,7 @@ import java.time.format.DateTimeFormatter;
 public class MeetingDate implements Comparable<MeetingDate> {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Meeting dates should be in the format DDMMYYYY";
+            "Meeting dates should be in the format DDMMYYYY and should be a valid day of the year";
     private final LocalDate date;
 
     /**

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_BIRTHDAY;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
@@ -39,8 +40,8 @@ public class CommandTestUtil {
     public static final String VALID_EMAIL_BOB = "bob@example.com";
     public static final String VALID_ADDRESS_AMY = "Block 312, Amy Street 1";
     public static final String VALID_ADDRESS_BOB = "Block 123, Bobby Street 3";
-    public static final LocalDate VALID_BIRTHDAY_AMY = LocalDate.of(1952, 12, 12);
-    public static final LocalDate VALID_BIRTHDAY_BOB = LocalDate.of(2000, 1, 1);
+    public static final LocalDate VALID_BIRTHDAY_AMY = LocalDate.of(1952, 1, 1);
+    public static final LocalDate VALID_BIRTHDAY_BOB = LocalDate.of(2000, 12, 31);
     public static final String VALID_PRODUCT_1 = "Product1";
     public static final String VALID_PRODUCT_2 = "Product2";
     public static final String INVALID_PRODUCT_1 = "Unadded Product";
@@ -60,6 +61,8 @@ public class CommandTestUtil {
     public static final String EMAIL_DESC_BOB = " " + PREFIX_EMAIL + VALID_EMAIL_BOB;
     public static final String ADDRESS_DESC_AMY = " " + PREFIX_ADDRESS + VALID_ADDRESS_AMY;
     public static final String ADDRESS_DESC_BOB = " " + PREFIX_ADDRESS + VALID_ADDRESS_BOB;
+    public static final String BIRTHDAY_DESC_AMY = " " + PREFIX_BIRTHDAY + "01011952";
+    public static final String BIRTHDAY_DESC_BOB = " " + PREFIX_BIRTHDAY + "31122000";
     public static final String PRODUCT_DESC_PRODUCT1 = " " + PREFIX_PRODUCT + VALID_PRODUCT_1;
     public static final String PRODUCT_DESC_PRODUCT2 = " " + PREFIX_PRODUCT + VALID_PRODUCT_2;
 
@@ -68,6 +71,10 @@ public class CommandTestUtil {
     public static final String INVALID_EMAIL_DESC = " " + PREFIX_EMAIL + "bob!yahoo"; // missing '@' symbol
     public static final String INVALID_ADDRESS_DESC = " " + PREFIX_ADDRESS; // empty string not allowed for addresses
     public static final String INVALID_PRODUCT_DESC = " " + PREFIX_PRODUCT + "hubby*"; // '*' not allowed in Products
+    public static final String INVALID_BIRTHDAY_1_DESC = " " + PREFIX_BIRTHDAY + "30022020"; // 30 feb not exist
+    public static final String INVALID_BIRTHDAY_2_DESC = " "
+            + PREFIX_BIRTHDAY + "29022021"; // 29 feb not exist non leap year
+    public static final String INVALID_BIRTHDAY_3_DESC = " " + PREFIX_BIRTHDAY + "31112020"; // 31 nov not exist
 
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";

--- a/src/test/java/seedu/address/logic/parser/AddClientCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddClientCommandParserTest.java
@@ -134,6 +134,7 @@ public class AddClientCommandParserTest {
     @Test
     public void parse_invalidBirthday_failure() {
         // boundary value analysis
+        // ep: [1jan, 31jan, 1feb, 28feb, ... (basically all valid dates)][invalid dates]
         // 30 feb, not exist
         assertParseFailure(parser,
                 NAME_DESC_BOB + PHONE_DESC_BOB + INVALID_BIRTHDAY_1_DESC, Birthday.MESSAGE_CONSTRAINTS);
@@ -147,7 +148,7 @@ public class AddClientCommandParserTest {
 
     @Test
     public void parse_validBirthday_success() {
-        // boundary value analysis
+        // boundary value analysis, using start and end values from valid dates
         Client expectedClient = new ClientBuilder(BOB)
                 .withProducts(VALID_PRODUCT_1).withBirthday(VALID_BIRTHDAY_AMY).build();
 

--- a/src/test/java/seedu/address/logic/parser/AddClientCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddClientCommandParserTest.java
@@ -3,9 +3,14 @@ package seedu.address.logic.parser;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.BIRTHDAY_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.BIRTHDAY_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_ADDRESS_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_BIRTHDAY_1_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_BIRTHDAY_2_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_BIRTHDAY_3_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
@@ -17,6 +22,8 @@ import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
 import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
 import static seedu.address.logic.commands.CommandTestUtil.PRODUCT_DESC_PRODUCT1;
 import static seedu.address.logic.commands.CommandTestUtil.PRODUCT_DESC_PRODUCT2;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_BIRTHDAY_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_BIRTHDAY_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PRODUCT_1;
@@ -30,6 +37,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.AddClientCommand;
 import seedu.address.model.client.Address;
+import seedu.address.model.client.Birthday;
 import seedu.address.model.client.Client;
 import seedu.address.model.client.Email;
 import seedu.address.model.client.Name;
@@ -121,5 +129,37 @@ public class AddClientCommandParserTest {
         assertParseFailure(parser, PREAMBLE_NON_EMPTY + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
                 + ADDRESS_DESC_BOB + PRODUCT_DESC_PRODUCT2 + PRODUCT_DESC_PRODUCT1,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddClientCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_invalidBirthday_failure() {
+        // boundary value analysis
+        // 30 feb, not exist
+        assertParseFailure(parser,
+                NAME_DESC_BOB + PHONE_DESC_BOB + INVALID_BIRTHDAY_1_DESC, Birthday.MESSAGE_CONSTRAINTS);
+        // 29 feb 2001, non leap year
+        assertParseFailure(parser,
+                NAME_DESC_AMY + PHONE_DESC_AMY + INVALID_BIRTHDAY_2_DESC, Birthday.MESSAGE_CONSTRAINTS);
+        // 31 nov, not exist
+        assertParseFailure(parser,
+                NAME_DESC_AMY + PHONE_DESC_AMY + INVALID_BIRTHDAY_3_DESC, Birthday.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_validBirthday_success() {
+        // boundary value analysis
+        Client expectedClient = new ClientBuilder(BOB)
+                .withProducts(VALID_PRODUCT_1).withBirthday(VALID_BIRTHDAY_AMY).build();
+
+        // 1 jan
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
+                + ADDRESS_DESC_BOB + PRODUCT_DESC_PRODUCT1 + BIRTHDAY_DESC_AMY, new AddClientCommand(expectedClient));
+
+        Client expectedClient2 = new ClientBuilder(BOB)
+                .withProducts(VALID_PRODUCT_1).withBirthday(VALID_BIRTHDAY_BOB).build();
+
+        // 31 dec
+        assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
+                + ADDRESS_DESC_BOB + PRODUCT_DESC_PRODUCT1 + BIRTHDAY_DESC_BOB, new AddClientCommand(expectedClient2));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -1,11 +1,14 @@
 package seedu.address.logic.parser;
 
+import static java.time.format.ResolverStyle.STRICT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ELEMENT;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
@@ -25,12 +28,18 @@ public class ParserUtilTest {
     private static final String INVALID_PHONE = "+651234";
     private static final String INVALID_ADDRESS = " ";
     private static final String INVALID_EMAIL = "example.com";
+    private static final String INVALID_DATE = "29022021";
+    private static final String INVALID_BIRTHDAY = "29022021";
     private static final String INVALID_PRODUCT = "#Invalid product";
 
     private static final String VALID_NAME = "Rachel Walker";
     private static final String VALID_PHONE = "12345678";
     private static final String VALID_ADDRESS = "123 Main Street #0505";
     private static final String VALID_EMAIL = "rachel@example.com";
+    private static final String VALID_DATE = "28022021";
+    private static final String VALID_START_TIME_1 = "1200";
+    private static final String VALID_END_TIME_1 = "1300";
+    private static final String VALID_BIRTHDAY = "28022021";
     private static final String VALID_PRODUCT_1 = "Product1";
     private static final String VALID_PRODUCT_2 = "Product2";
 
@@ -146,6 +155,36 @@ public class ParserUtilTest {
         String emailWithWhitespace = WHITESPACE + VALID_EMAIL + WHITESPACE;
         Email expectedEmail = new Email(VALID_EMAIL);
         assertEquals(expectedEmail, ParserUtil.parseEmail(emailWithWhitespace));
+    }
+
+    @Test
+    public void parseDate_nullDate_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseDate(null, "birthday"));
+    }
+
+    @Test
+    public void parseDate_validBirthday_returnsLocalDate() throws Exception {
+        LocalDate expectedDate = LocalDate.parse(
+                        VALID_BIRTHDAY,
+                        DateTimeFormatter.ofPattern("ddMMuuuu").withResolverStyle(STRICT));
+        // test heuristics: valid input at least once: valid birthday, valid meeting
+        // ep: valid birthday, invalid birthday
+        assertEquals(expectedDate, ParserUtil.parseDate(VALID_BIRTHDAY, "birthday"));
+    }
+
+    @Test
+    public void parseDate_validMeeting_returnsLocalDate() throws Exception {
+        LocalDate expectedDate = LocalDate.parse(
+                VALID_DATE,
+                DateTimeFormatter.ofPattern("ddMMuuuu").withResolverStyle(STRICT));
+        // test heuristics: valid input at least once: valid birthday, valid meeting
+        assertEquals(expectedDate, ParserUtil.parseDate(VALID_DATE, "meeting"));
+    }
+
+    @Test
+    public void parseDate_invalidBirthday_throwsParseException() {
+        // ep: valid birthday, invalid birthday
+        assertThrows(ParseException.class, () -> ParserUtil.parseDate(INVALID_BIRTHDAY, "birthday"));
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/ClientBuilder.java
+++ b/src/test/java/seedu/address/testutil/ClientBuilder.java
@@ -93,6 +93,13 @@ public class ClientBuilder {
         this.email = Optional.of(new Email(email));
         return this;
     }
+    /**
+     * Sets the {@code Birthday} of the {@code Client} that we are building.
+     */
+    public ClientBuilder withBirthday(LocalDate birthday) {
+        this.birthday = Optional.of(new Birthday(birthday));
+        return this;
+    }
 
     /**
      * Parses the {@code products} into a {@code Set<Product>} and set it to the {@code Client} that we are building.


### PR DESCRIPTION
Solution:
Resolver style of STRICT was used. Since `ParserUtil#parseDate` is used for all dates, all dates have been fixed

Tests were also written to check for it. Manual testing was done.
`editMeeting` date
<img width="732" alt="image" src="https://user-images.githubusercontent.com/63795894/198867057-89f5429f-589f-4064-af4b-fd70356a53fd.png">

`addClient`birthday
<img width="722" alt="image" src="https://user-images.githubusercontent.com/63795894/198867130-8f009173-ec20-499f-ae73-78e56a575557.png">

`editClient` birthday
<img width="736" alt="image" src="https://user-images.githubusercontent.com/63795894/198867127-a5ac5c0d-b713-4c00-864e-b14be1b82704.png">

`addMeeting` date
<img width="723" alt="image" src="https://user-images.githubusercontent.com/63795894/198867141-0e9bf7d6-cf61-4fec-9d95-196608251c77.png">


Closes #249, #244 