### PR TITLE
Mention invalid input in exception message

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -27,7 +27,7 @@ import seedu.address.model.product.Product;
  */
 public class ParserUtil {
 
-    public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
+    public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer";
     public static final String MESSAGE_INVALID_DATE_KEYWORD =
             "The date keyword should be one of tomorrow, week, or month";
 
@@ -39,7 +39,7 @@ public class ParserUtil {
     public static Index parseIndex(String oneBasedIndex) throws ParseException {
         String trimmedIndex = oneBasedIndex.trim();
         if (!StringUtil.isNonZeroUnsignedInteger(trimmedIndex)) {
-            throw new ParseException(MESSAGE_INVALID_INDEX);
+            throw new ParseException(MESSAGE_INVALID_INDEX, trimmedIndex);
         }
         return Index.fromOneBased(Integer.parseInt(trimmedIndex));
     }
@@ -54,7 +54,7 @@ public class ParserUtil {
         requireNonNull(name);
         String trimmedName = name.trim();
         if (!Name.isValidName(trimmedName)) {
-            throw new ParseException(Name.MESSAGE_CONSTRAINTS);
+            throw new ParseException(Name.MESSAGE_CONSTRAINTS, trimmedName);
         }
         return new Name(trimmedName);
     }
@@ -69,7 +69,7 @@ public class ParserUtil {
         requireNonNull(phone);
         String trimmedPhone = phone.trim();
         if (!Phone.isValidPhone(trimmedPhone)) {
-            throw new ParseException(Phone.MESSAGE_CONSTRAINTS);
+            throw new ParseException(Phone.MESSAGE_CONSTRAINTS, trimmedPhone);
         }
         return new Phone(trimmedPhone);
     }
@@ -84,7 +84,7 @@ public class ParserUtil {
         requireNonNull(address);
         String trimmedAddress = address.trim();
         if (!Address.isValidAddress(trimmedAddress)) {
-            throw new ParseException(Address.MESSAGE_CONSTRAINTS);
+            throw new ParseException(Address.MESSAGE_CONSTRAINTS, trimmedAddress);
         }
         return new Address(trimmedAddress);
     }
@@ -99,7 +99,7 @@ public class ParserUtil {
         requireNonNull(email);
         String trimmedEmail = email.trim();
         if (!Email.isValidEmail(trimmedEmail)) {
-            throw new ParseException(Email.MESSAGE_CONSTRAINTS);
+            throw new ParseException(Email.MESSAGE_CONSTRAINTS, trimmedEmail);
         }
         return new Email(trimmedEmail);
     }
@@ -113,9 +113,9 @@ public class ParserUtil {
             return LocalDate.parse(date, DateTimeFormatter.ofPattern("ddMMyyyy"));
         } catch (DateTimeParseException e) {
             if (type.equals("meeting")) {
-                throw new ParseException(MeetingDate.MESSAGE_CONSTRAINTS);
+                throw new ParseException(MeetingDate.MESSAGE_CONSTRAINTS, date);
             } else {
-                throw new ParseException(Birthday.MESSAGE_CONSTRAINTS);
+                throw new ParseException(Birthday.MESSAGE_CONSTRAINTS, date);
             }
         }
     }
@@ -135,7 +135,7 @@ public class ParserUtil {
         case "month":
             return DateKeyword.THIS_MONTH;
         default:
-            throw new ParseException(MESSAGE_INVALID_DATE_KEYWORD);
+            throw new ParseException(MESSAGE_INVALID_DATE_KEYWORD, dateKeyword);
         }
     }
 
@@ -149,7 +149,7 @@ public class ParserUtil {
             LocalTime parsedTime = LocalTime.parse(time, DateTimeFormatter.ofPattern("HHmm"));
             return new MeetingTime(parsedTime);
         } catch (DateTimeParseException e) {
-            throw new ParseException(MeetingTime.MESSAGE_CONSTRAINTS);
+            throw new ParseException(MeetingTime.MESSAGE_CONSTRAINTS, time);
         }
     }
 
@@ -163,7 +163,7 @@ public class ParserUtil {
         requireNonNull(product);
         String trimmedProduct = product.trim();
         if (!Product.isValidProductName(trimmedProduct)) {
-            throw new ParseException(Product.MESSAGE_CONSTRAINTS);
+            throw new ParseException(Product.MESSAGE_CONSTRAINTS, product);
         }
         return new Product(trimmedProduct);
     }

--- a/src/main/java/seedu/address/logic/parser/exceptions/ParseException.java
+++ b/src/main/java/seedu/address/logic/parser/exceptions/ParseException.java
@@ -11,6 +11,16 @@ public class ParseException extends IllegalValueException {
         super(message);
     }
 
+    /**
+     * Constructor for parse exceptions that are caused by invalid
+     * values. Prints a message as well as the invalid value.
+     * @param message
+     * @param invalidValue
+     */
+    public ParseException(String message, String invalidValue) {
+        super(message + ".\n\"" + invalidValue + "\" is invalid!");
+    }
+
     public ParseException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -64,10 +64,21 @@ public class CommandTestUtil {
     public static final String PRODUCT_DESC_PRODUCT2 = " " + PREFIX_PRODUCT + VALID_PRODUCT_2;
 
     public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
+    public static final String INVALID_NAME_DESC_EXPECTED_PARSE_EXCEPTION_MESSAGE =
+            ".\n\"" + "James&" + "\" is invalid!";
     public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones
+    public static final String INVALID_PHONE_DESC_EXPECTED_PARSE_EXCEPTION_MESSAGE =
+            ".\n\"" + "911a" + "\" is invalid!";
     public static final String INVALID_EMAIL_DESC = " " + PREFIX_EMAIL + "bob!yahoo"; // missing '@' symbol
+    public static final String INVALID_EMAIL_DESC_EXPECTED_PARSE_EXCEPTION_MESSAGE =
+            ".\n\"" + "bob!yahoo" + "\" is invalid!";
+
     public static final String INVALID_ADDRESS_DESC = " " + PREFIX_ADDRESS; // empty string not allowed for addresses
+    public static final String INVALID_ADDRESS_DESC_EXPECTED_PARSE_EXCEPTION_MESSAGE =
+            ".\n\"" + "" + "\" is invalid!";
     public static final String INVALID_PRODUCT_DESC = " " + PREFIX_PRODUCT + "hubby*"; // '*' not allowed in Products
+    public static final String INVALID_PRODUCT_DESC_EXPECTED_PARSE_EXCEPTION_MESSAGE =
+            ".\n\"" + "hubby*" + "\" is invalid!";
 
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";

--- a/src/test/java/seedu/address/logic/parser/AddClientCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddClientCommandParserTest.java
@@ -6,9 +6,13 @@ import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_ADDRESS_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_ADDRESS_DESC_EXPECTED_PARSE_EXCEPTION_MESSAGE;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC_EXPECTED_PARSE_EXCEPTION_MESSAGE;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC_EXPECTED_PARSE_EXCEPTION_MESSAGE;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_PHONE_DESC_EXPECTED_PARSE_EXCEPTION_MESSAGE;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
@@ -99,23 +103,27 @@ public class AddClientCommandParserTest {
     public void parse_invalidValue_failure() {
         // invalid name
         assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + PRODUCT_DESC_PRODUCT2 + PRODUCT_DESC_PRODUCT1, Name.MESSAGE_CONSTRAINTS);
+                + PRODUCT_DESC_PRODUCT2 + PRODUCT_DESC_PRODUCT1,
+                Name.MESSAGE_CONSTRAINTS + INVALID_NAME_DESC_EXPECTED_PARSE_EXCEPTION_MESSAGE);
 
         // invalid phone
         assertParseFailure(parser, NAME_DESC_BOB + INVALID_PHONE_DESC + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + PRODUCT_DESC_PRODUCT2 + PRODUCT_DESC_PRODUCT1, Phone.MESSAGE_CONSTRAINTS);
+                + PRODUCT_DESC_PRODUCT2 + PRODUCT_DESC_PRODUCT1,
+                Phone.MESSAGE_CONSTRAINTS + INVALID_PHONE_DESC_EXPECTED_PARSE_EXCEPTION_MESSAGE);
 
         // invalid email
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + INVALID_EMAIL_DESC + ADDRESS_DESC_BOB
-                + PRODUCT_DESC_PRODUCT2 + PRODUCT_DESC_PRODUCT1, Email.MESSAGE_CONSTRAINTS);
+                + PRODUCT_DESC_PRODUCT2 + PRODUCT_DESC_PRODUCT1,
+                Email.MESSAGE_CONSTRAINTS + INVALID_EMAIL_DESC_EXPECTED_PARSE_EXCEPTION_MESSAGE);
 
         // invalid address
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + INVALID_ADDRESS_DESC
-                + PRODUCT_DESC_PRODUCT2 + PRODUCT_DESC_PRODUCT1, Address.MESSAGE_CONSTRAINTS);
+                + PRODUCT_DESC_PRODUCT2 + PRODUCT_DESC_PRODUCT1,
+                Address.MESSAGE_CONSTRAINTS + INVALID_ADDRESS_DESC_EXPECTED_PARSE_EXCEPTION_MESSAGE);
 
         // two invalid values, only first invalid value reported
         assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB + INVALID_ADDRESS_DESC,
-                Name.MESSAGE_CONSTRAINTS);
+                Name.MESSAGE_CONSTRAINTS + INVALID_NAME_DESC_EXPECTED_PARSE_EXCEPTION_MESSAGE);
 
         // non-empty preamble
         assertParseFailure(parser, PREAMBLE_NON_EMPTY + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB

--- a/src/test/java/seedu/address/logic/parser/AddProductCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddProductCommandParserTest.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_PRODUCT_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_PRODUCT_DESC_EXPECTED_PARSE_EXCEPTION_MESSAGE;
 import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
 import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
 import static seedu.address.logic.commands.CommandTestUtil.PRODUCT_DESC_PRODUCT1;
@@ -45,7 +46,7 @@ public class AddProductCommandParserTest {
     public void parse_invalidValue_failure() {
         // invalid product name
         assertParseFailure(parser, INVALID_PRODUCT_DESC,
-                Product.MESSAGE_CONSTRAINTS);
+                Product.MESSAGE_CONSTRAINTS + INVALID_PRODUCT_DESC_EXPECTED_PARSE_EXCEPTION_MESSAGE);
 
         // non-empty preamble
         assertParseFailure(parser, PREAMBLE_NON_EMPTY + PRODUCT_DESC_PRODUCT1,

--- a/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandParserTest.java
@@ -6,10 +6,15 @@ import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_ADDRESS_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_ADDRESS_DESC_EXPECTED_PARSE_EXCEPTION_MESSAGE;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC_EXPECTED_PARSE_EXCEPTION_MESSAGE;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC_EXPECTED_PARSE_EXCEPTION_MESSAGE;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_PHONE_DESC_EXPECTED_PARSE_EXCEPTION_MESSAGE;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_PRODUCT_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_PRODUCT_DESC_EXPECTED_PARSE_EXCEPTION_MESSAGE;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
@@ -81,22 +86,30 @@ public class EditCommandParserTest {
 
     @Test
     public void parse_invalidValue_failure() {
-        assertParseFailure(parser, " i/1" + INVALID_NAME_DESC, Name.MESSAGE_CONSTRAINTS); // invalid name
-        assertParseFailure(parser, " i/1" + INVALID_PHONE_DESC, Phone.MESSAGE_CONSTRAINTS); // invalid phone
-        assertParseFailure(parser, " i/1" + INVALID_EMAIL_DESC, Email.MESSAGE_CONSTRAINTS); // invalid email
-        assertParseFailure(parser, " i/1" + INVALID_ADDRESS_DESC, Address.MESSAGE_CONSTRAINTS); // invalid address
-        assertParseFailure(parser, " i/1" + INVALID_PRODUCT_DESC, Product.MESSAGE_CONSTRAINTS); // invalid product
+        assertParseFailure(parser, " i/1" + INVALID_NAME_DESC,
+                Name.MESSAGE_CONSTRAINTS + INVALID_NAME_DESC_EXPECTED_PARSE_EXCEPTION_MESSAGE); // invalid name
+        assertParseFailure(parser, " i/1" + INVALID_PHONE_DESC,
+                Phone.MESSAGE_CONSTRAINTS + INVALID_PHONE_DESC_EXPECTED_PARSE_EXCEPTION_MESSAGE); // invalid phone
+        assertParseFailure(parser, " i/1" + INVALID_EMAIL_DESC,
+                Email.MESSAGE_CONSTRAINTS + INVALID_EMAIL_DESC_EXPECTED_PARSE_EXCEPTION_MESSAGE); // invalid email
+        assertParseFailure(parser, " i/1" + INVALID_ADDRESS_DESC,
+                Address.MESSAGE_CONSTRAINTS + INVALID_ADDRESS_DESC_EXPECTED_PARSE_EXCEPTION_MESSAGE); // invalid address
+        assertParseFailure(parser, " i/1" + INVALID_PRODUCT_DESC,
+                Product.MESSAGE_CONSTRAINTS + INVALID_PRODUCT_DESC_EXPECTED_PARSE_EXCEPTION_MESSAGE); // invalid product
 
         // invalid phone followed by valid email
-        assertParseFailure(parser, " i/1" + INVALID_PHONE_DESC + EMAIL_DESC_AMY, Phone.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, " i/1" + INVALID_PHONE_DESC + EMAIL_DESC_AMY,
+                Phone.MESSAGE_CONSTRAINTS + INVALID_PHONE_DESC_EXPECTED_PARSE_EXCEPTION_MESSAGE);
 
         // valid phone followed by invalid phone. The test case for invalid phone followed by valid phone
         // is tested at {@code parse_invalidValueFollowedByValidValue_success()}
-        assertParseFailure(parser, " i/1" + PHONE_DESC_BOB + INVALID_PHONE_DESC, Phone.MESSAGE_CONSTRAINTS);
+        assertParseFailure(parser, " i/1" + PHONE_DESC_BOB + INVALID_PHONE_DESC,
+                Phone.MESSAGE_CONSTRAINTS + INVALID_PHONE_DESC_EXPECTED_PARSE_EXCEPTION_MESSAGE);
 
         // multiple invalid values, but only the first invalid value is captured
         assertParseFailure(parser, " i/1" + INVALID_NAME_DESC + INVALID_EMAIL_DESC
-                        + VALID_ADDRESS_AMY + VALID_PHONE_AMY, Name.MESSAGE_CONSTRAINTS);
+                        + VALID_ADDRESS_AMY + VALID_PHONE_AMY,
+                Name.MESSAGE_CONSTRAINTS + INVALID_NAME_DESC_EXPECTED_PARSE_EXCEPTION_MESSAGE);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -43,8 +43,9 @@ public class ParserUtilTest {
 
     @Test
     public void parseIndex_outOfRangeInput_throwsParseException() {
-        assertThrows(ParseException.class, MESSAGE_INVALID_INDEX, ()
-            -> ParserUtil.parseIndex(Long.toString(Integer.MAX_VALUE + 1)));
+        String outOfRangeIndex = Long.toString(Integer.MAX_VALUE + 1);
+        assertThrows(ParseException.class, MESSAGE_INVALID_INDEX + ".\n\"" + outOfRangeIndex + "\" is invalid!" , ()
+            -> ParserUtil.parseIndex(outOfRangeIndex));
     }
 
     @Test


### PR DESCRIPTION
close #222 
Added sentence to parse exception message mentioning which section in command was invalid:

![image](https://user-images.githubusercontent.com/93027319/199228399-d3f52f67-3018-44ef-a1b9-732147af1985.png)

Instead of changing the parser as recommended by reviewer, just indicate which section was wrong.
This will also give troubleshooting feedback to the user.