### PR TITLE
Fix error message to display message specific to the index

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -7,7 +7,8 @@ public class Messages {
 
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
-    public static final String MESSAGE_INVALID_CLIENT_DISPLAYED_INDEX = "The client index provided is invalid";
+    public static final String MESSAGE_INVALID_CLIENT_DISPLAYED_INDEX = "The client index provided could not be " +
+            "found in the list of clients.";
     public static final String MESSAGE_CLIENTS_LISTED_OVERVIEW = "%1$d client listed!";
     public static final String MESSAGE_INVALID_MEETING_DISPLAYED_INDEX = "The meeting index provided is invalid";
     public static final String MESSAGE_INVALID_PRODUCT_DISPLAYED_INDEX = "The product index provided is invalid";

--- a/src/main/java/seedu/address/logic/parser/ViewClientCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ViewClientCommandParser.java
@@ -28,14 +28,8 @@ public class ViewClientCommandParser implements Parser<ViewClientCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewClientCommand.MESSAGE_USAGE));
         }
 
-        Index index;
-        try {
-            index = ParserUtil.parseIndex(argumentMultimap.getValue(PREFIX_INDEX).get());
-            return new ViewClientCommand(index);
-        } catch (ParseException pe) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, ViewClientCommand.MESSAGE_USAGE), pe);
-        }
+        Index index = ParserUtil.parseIndex(argumentMultimap.getValue(PREFIX_INDEX).get());
+        return new ViewClientCommand(index);
     }
 
     private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {


### PR DESCRIPTION
Before, entering a negative integer will result in the command usage being displayed. After this change, entering a negative integer will instead result in the message "Index is not a non-zero unsigned integer." being displayed. Entering a positive integer that is out of bounds of the client list will display the more specific message, "The client index provided could not be found in the list of clients."