### PR TITLE
Fix a bug where an edited meeting will conflict with itself

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditMeetingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditMeetingCommand.java
@@ -21,6 +21,7 @@ import seedu.address.model.meeting.Description;
 import seedu.address.model.meeting.Meeting;
 import seedu.address.model.meeting.MeetingDate;
 import seedu.address.model.meeting.MeetingTime;
+import seedu.address.model.meeting.exceptions.ConflictingMeetingException;
 
 
 /**
@@ -44,7 +45,8 @@ public class EditMeetingCommand extends Command {
 
     public static final String MESSAGE_EDIT_MEETING_SUCCESS = "Edited Meeting: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
-    public static final String MESSAGE_DUPLICATE_MEETING = "This meeting already exists in MyInsuRec.";
+    public static final String MESSAGE_DUPLICATE_MEETING =
+            "This meeting conflicts with another that exists in MyInsuRec";
 
     private final Index index;
     private final EditMeetingDescriptor editMeetingDescriptor;
@@ -73,12 +75,12 @@ public class EditMeetingCommand extends Command {
         Meeting meetingToEdit = lastShownList.get(index.getZeroBased());
         Meeting editedMeeting = createEditedMeeting(meetingToEdit, editMeetingDescriptor);
 
-        if (model.hasMeeting(editedMeeting)) {
+        // update meeting list
+        try {
+            model.setMeeting(meetingToEdit, editedMeeting);
+        } catch (ConflictingMeetingException e) {
             throw new CommandException(MESSAGE_DUPLICATE_MEETING);
         }
-
-        // update meeting list
-        model.setMeeting(meetingToEdit, editedMeeting);
 
         // update meeting in client
         Client client = meetingToEdit.getClient();

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -7,6 +7,7 @@ import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.model.client.Client;
 import seedu.address.model.meeting.Meeting;
+import seedu.address.model.meeting.exceptions.ConflictingMeetingException;
 import seedu.address.model.product.Product;
 
 /**
@@ -99,7 +100,7 @@ public interface Model {
      * {@code target} must exist in the MyInsuRec.
      * The meeting identity of {@code editedMeeting} must not be the same as another existing meeting in the MyInsuRec.
      */
-    void setMeeting(Meeting target, Meeting editedMeeting);
+    void setMeeting(Meeting target, Meeting editedMeeting) throws ConflictingMeetingException;
 
     /**
      * Adds the given product.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -13,6 +13,7 @@ import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.client.Client;
 import seedu.address.model.meeting.Meeting;
+import seedu.address.model.meeting.exceptions.ConflictingMeetingException;
 import seedu.address.model.product.Product;
 
 /**
@@ -145,7 +146,7 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public void setMeeting(Meeting target, Meeting editedMeeting) {
+    public void setMeeting(Meeting target, Meeting editedMeeting) throws ConflictingMeetingException {
         requireAllNonNull(target, editedMeeting);
 
         myInsuRec.setMeeting(target, editedMeeting);

--- a/src/main/java/seedu/address/model/MyInsuRec.java
+++ b/src/main/java/seedu/address/model/MyInsuRec.java
@@ -10,6 +10,7 @@ import seedu.address.model.client.ClientRebuilder;
 import seedu.address.model.client.UniqueClientList;
 import seedu.address.model.meeting.Meeting;
 import seedu.address.model.meeting.NoConflictMeetingList;
+import seedu.address.model.meeting.exceptions.ConflictingMeetingException;
 import seedu.address.model.product.Product;
 import seedu.address.model.product.UniqueProductList;
 
@@ -170,7 +171,7 @@ public class MyInsuRec implements ReadOnlyMyInsuRec {
      * The Meeting identity of {@code editedMeeting} must not be the same as
      * another existing Meeting in MyInsuRec.
      */
-    public void setMeeting(Meeting target, Meeting editedMeeting) {
+    public void setMeeting(Meeting target, Meeting editedMeeting) throws ConflictingMeetingException {
         requireNonNull(editedMeeting);
 
         meetings.setMeeting(target, editedMeeting);

--- a/src/main/java/seedu/address/model/meeting/NoConflictMeetingList.java
+++ b/src/main/java/seedu/address/model/meeting/NoConflictMeetingList.java
@@ -38,6 +38,16 @@ public class NoConflictMeetingList implements Iterable<Meeting> {
     }
 
     /**
+     * Returns true if the list contains a meeting that is not the given {@code except} and
+     * conflicts with {@code toCheck}.
+     */
+    public boolean containsExcept(Meeting toCheck, Meeting except) {
+        requireAllNonNull(toCheck, except);
+        return internalList.stream().anyMatch(meeting ->
+                toCheck.willConflict(meeting) && except != meeting);
+    }
+
+    /**
      * Returns true if the list contains an identical meeting as the given argument.
      */
     public boolean containsSpecific(Meeting toCheck) {
@@ -62,7 +72,7 @@ public class NoConflictMeetingList implements Iterable<Meeting> {
      * {@code target} must exist in the list.
      * The {@code editedMeeting} must not conflict with another existing meeting in the list.
      */
-    public void setMeeting(Meeting target, Meeting editedMeeting) {
+    public void setMeeting(Meeting target, Meeting editedMeeting) throws ConflictingMeetingException {
         requireAllNonNull(target, editedMeeting);
 
         int index = internalList.indexOf(target);
@@ -70,7 +80,7 @@ public class NoConflictMeetingList implements Iterable<Meeting> {
             throw new MeetingNotFoundException();
         }
 
-        if (contains(editedMeeting) && !target.willConflict(editedMeeting)) {
+        if (containsExcept(editedMeeting, target)) {
             // Any timing conflicts with the original timing is okay
             throw new ConflictingMeetingException();
         }


### PR DESCRIPTION
Before, if we tried editing a meeting, e.g., from 1300 to 1400 and make its start time 1230, it will give an error that there is a conflicting meeting because it conflicts with the current version of itself.
After this fix, the meetings list is only checked for conflicts with meetings other than the one being edited.