### PR TITLE
Fix delProduct while viewClient

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -18,6 +18,6 @@ public class ClearCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.setMyInsuRec(new MyInsuRec());
-        return new CommandResult(MESSAGE_SUCCESS);
+        return new CommandResult(MESSAGE_SUCCESS, CommandSpecific.CLIENT);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/DeleteProductCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteProductCommand.java
@@ -43,7 +43,8 @@ public class DeleteProductCommand extends Command {
 
         Product productToDelete = lastShownList.get(targetIndex.getZeroBased());
         model.deleteProduct(productToDelete);
-        return new CommandResult(String.format(MESSAGE_DELETE_PRODUCT_SUCCESS, productToDelete));
+        return new CommandResult(
+                String.format(MESSAGE_DELETE_PRODUCT_SUCCESS, productToDelete), CommandSpecific.PRODUCT);
     }
 
     @Override


### PR DESCRIPTION
If we are viewing a client, then we call delProduct, the active client will be deleted and replaced with a new one. A blank screen will be shown.

This is easily fixed by forcing the panel to switch to the product view.